### PR TITLE
Removing count for global and single services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-scheduler
-
+coco-fleet-deployer

--- a/deployer_test.go
+++ b/deployer_test.go
@@ -19,10 +19,9 @@ services:
     version: latest
   - name: annotations-api@.service 
     version: latest
-    count: 1
+    count: 0
   - name: annotations-api-sidekick@.service 
-    version: latest
-    count: 1`)
+    version: latest`)
 	yaml.Unmarshal(serviceYaml, &services)
 	return services
 
@@ -51,5 +50,12 @@ func TestBuildWantedUnits(t *testing.T) {
 	if err != nil {
 		t.Errorf("wanted units threw an error: %v", err)
 	}
+	if wantedUnits["annotations-api@.service"] != nil {
+		t.Fatalf("Scheduled a '@' unit with 0 count")
+	}
+	if wantedUnits["annotations-api-sidekick@.service"] != nil {
+		t.Fatalf("Scheduled a '@' unit without a count")
+	}
+
 	t.Logf("Passed with wanted units: %v", wantedUnits)
 }

--- a/deployer_test.go
+++ b/deployer_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"gopkg.in/yaml.v2"
+	"net/http"
+	"testing"
+)
+
+func mockServiceDefinitionGetter(httpClient *http.Client) (services services) {
+	serviceYaml := []byte(`---
+services:
+  - name: mongodb@.service
+    version: latest
+    count: 3
+  - name: mongodb-sidekick@.service
+    version: latest
+    count: 3
+  - name: mongodb-configurator.service
+    version: latest
+  - name: annotations-api@.service 
+    version: latest
+    count: 1
+  - name: annotations-api-sidekick@.service 
+    version: latest
+    count: 1`)
+	yaml.Unmarshal(serviceYaml, &services)
+	return services
+
+}
+
+type sfr struct{}
+
+func (sfr *sfr) renderServiceFile(name string, context ...interface{}) (string, error) {
+	return `[Unit]
+Description=Deployer
+
+[Service]
+TimeoutStartSec=600
+ExecStartPre=-/usr/bin/docker kill %p-%i
+ExecStartPre=-/usr/bin/docker rm %p-%i
+ExecStartPre=/usr/bin/docker pull coco/coco-fleet-deployer
+ExecStart=/bin/bash -c "docker run --rm --name %p-%i --env=\"FLEET_ENDPOINT=http://$HOSTNAME:49153\" --env=\"SERVICE_FILES_URI=https://raw.githubusercontent.com/Financial-Times/fleet/master/service-files/\" --env=\"SERVICES_DEFINITION_FILE_URI=https://raw.githubusercontent.com/Financial-Times/fleet/master/services.yaml\" --env=\"INTERVAL_IN_SECONDS_BETWEEN_DEPLOYS=60\" --env=\"DESTROY=false\" coco/coco-fleet-deployer"
+ExecStop=/usr/bin/docker stop -t 3 %p-%i
+`, nil
+}
+
+func TestBuildWantedUnits(t *testing.T) {
+	sfr := &sfr{}
+	d, err := newDeployer(mockServiceDefinitionGetter)
+	wantedUnits, err := d.buildWantedUnits(sfr)
+	if err != nil {
+		t.Errorf("wanted units threw an error: %v", err)
+	}
+	t.Logf("Passed with wanted units: %v", wantedUnits)
+}


### PR DESCRIPTION
Currently still allows you to pass a count, goyaml will init to 0 if its
absent anyway. Also added a simple unit test.