### PR TITLE
Check the DesiredState of the unit instead of Current

### DIFF
--- a/deployer.go
+++ b/deployer.go
@@ -192,8 +192,8 @@ func (d *deployer) launchAll() error {
 
 	// start everything that's not started
 	for _, u := range currentUnits {
-		if u.CurrentState != "launched" {
-			log.Printf("INFO Current state: %s", u.CurrentState)
+		if u.DesiredState != "launched" {
+			log.Printf("INFO Desired state: %s", u.DesiredState)
 			err := d.fleetapi.SetUnitTargetState(u.Name, "launched")
 			if err != nil {
 				return err


### PR DESCRIPTION
Global services will forever show "inactive". Also, we don't really want
to check the "current" state, deployer tells fleet that unit should be
"launched", that changes the desiredState. If the unit isn't in the
"lunched" state, fleet already knows this, there is no need to ping it
again