### PR TITLE
Zero downtime deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 coco-fleet-deployer
+*.exe
+tags

--- a/deployer.go
+++ b/deployer.go
@@ -176,8 +176,6 @@ func (d *deployer) launchAll(wantedUnits, currentUnits map[string]*schema.Unit, 
 	deployedUnits := make(map[string]bool)
 
 	for _, u := range wantedUnits {
-
-		//because we are not calling deployUnit before, have to do this check here
 		currentUnit, err := d.fleetapi.Unit(u.Name)
 		if err != nil {
 			return err
@@ -185,11 +183,15 @@ func (d *deployer) launchAll(wantedUnits, currentUnits map[string]*schema.Unit, 
 
 		if currentUnit == nil {
 			err := d.fleetapi.CreateUnit(u)
+			currentUnits[u.Name] = u
 			if err != nil {
 				return err
 			}
 		}
+		time.Sleep(time.Second * 1)
+	}
 
+	for _, u := range wantedUnits {
 		// unit may have already been deployed - all nodes of a service get deployed,
 		// when the first one appears in the wanted list
 		if _, ok := deployedUnits[u.Name]; ok {

--- a/deployer.go
+++ b/deployer.go
@@ -176,6 +176,20 @@ func (d *deployer) launchAll(wantedUnits, currentUnits map[string]*schema.Unit, 
 	deployedUnits := make(map[string]bool)
 
 	for _, u := range wantedUnits {
+
+		//because we are not calling deployUnit before, have to do this check here
+		currentUnit, err := d.fleetapi.Unit(u.Name)
+		if err != nil {
+			return err
+		}
+
+		if currentUnit == nil {
+			err := d.fleetapi.CreateUnit(u)
+			if err != nil {
+				return err
+			}
+		}
+
 		// unit may have already been deployed - all nodes of a service get deployed,
 		// when the first one appears in the wanted list
 		if _, ok := deployedUnits[u.Name]; ok {
@@ -258,7 +272,7 @@ func (d *deployer) performSequentialDeployment(u *schema.Unit, zddUnits map[stri
 					return nil, err
 				}
 
-				fmt.Printf("INFO Sidekick status: [%v]\n", sidekickStatus.CurrentState)
+				log.Printf("INFO Sidekick status: [%v]\n", sidekickStatus.CurrentState)
 				if sidekickStatus.CurrentState == "launched" {
 					tickerChan.Stop()
 					break

--- a/deployer.go
+++ b/deployer.go
@@ -32,11 +32,12 @@ type services struct {
 }
 
 type service struct {
-	Name         string `yaml:"name"`
-	Version      string `yaml:"version"`
-	Count        int    `yaml:"count"`
-	URI          string `yaml:"uri"`
-	DesiredState string `yaml:"desiredState"`
+	Name                 string `yaml:"name"`
+	Version              string `yaml:"version"`
+	Count                int    `yaml:"count"`
+	URI                  string `yaml:"uri"`
+	DesiredState         string `yaml:"desiredState"`
+	SequentialDeployment bool   `yaml:"sequentialDeployment"`
 }
 
 type serviceDefinitionClient interface {
@@ -448,7 +449,9 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]int, 
 				}
 
 				units[u.Name] = u
-				serviceCount[strings.Split(srv.Name, "@")[0]] = srv.Count
+				if srv.SequentialDeployment {
+					serviceCount[strings.Split(srv.Name, "@")[0]] = srv.Count
+				}
 			}
 		} else {
 			log.Printf("WARNING skipping service: %s, incorrect service definition", srv.Name)

--- a/deployer.go
+++ b/deployer.go
@@ -213,7 +213,7 @@ func (d *deployer) performSequentialDeployment(u *schema.Unit, serviceCount map[
 	for i := 1; i <= nrOfNodes; i++ {
 		// generate unit name with number - the one we have originally might not be
 		// the 1st node
-		unitName := fmt.Sprintf("%v@%d%v", serviceName, i, strings.Split(u.Name, ".")[1])
+		unitName := fmt.Sprintf("%v@%d.%v", serviceName, i, strings.Split(u.Name, ".")[1])
 
 		// start the service
 		err := d.fleetapi.SetUnitTargetState(unitName, u.DesiredState)
@@ -250,6 +250,7 @@ func (d *deployer) performSequentialDeployment(u *schema.Unit, serviceCount map[
 					return nil, err
 				}
 
+				fmt.Printf("INFO Sidekick status: [%v]\n", sidekickStatus.CurrentState)
 				if sidekickStatus.CurrentState == "launched" {
 					tickerChan.Stop()
 					break
@@ -261,6 +262,7 @@ func (d *deployer) performSequentialDeployment(u *schema.Unit, serviceCount map[
 				log.Printf("WARN Service [%v] didn't start up in time", unitName)
 				break
 			}
+			break
 		}
 	}
 	return deployedUnits, nil

--- a/deployer.go
+++ b/deployer.go
@@ -267,6 +267,9 @@ func (d *deployer) deployAll() error {
 
 	// create any missing units
 	for _, u := range wantedUnits {
+		//basically reproduce the bahvior of the deployUnit() function but with the
+		//sequential deployment thrown in
+
 		isNew, err := d.isNewUnit(u)
 		if err != nil {
 			log.Printf("WARNING Failed to determine if it's a new unit %s: %v [SKIPPING]", u.Name, err)
@@ -274,7 +277,7 @@ func (d *deployer) deployAll() error {
 		}
 
 		if isNew {
-			log.Printf("Unit [%v] is new", u.Name)
+			log.Printf("DEBUG: Unit [%v] is new", u.Name)
 			err := d.fleetapi.CreateUnit(u)
 			if err != nil {
 				log.Printf("WARNING Failed to create unit %s: %v [SKIPPING]", u.Name, err)
@@ -289,15 +292,16 @@ func (d *deployer) deployAll() error {
 		}
 
 		if !isUpdated {
-			log.Printf("Unit [%v] is not updated", u.Name)
 			continue
 		}
 
-		log.Printf("Unit [%v] is  updated", u.Name)
+		//for updated apps which need zero downtime deployment, we do that here
+		log.Printf("DEBUG Unit [%v] is  updated", u.Name)
 		if _, ok := zddUnits[u.Name]; ok {
-			log.Printf("Unit [%v] is ZDD ", u.Name)
+			log.Printf("DEBUG Unit [%v] is ZDD ", u.Name)
+
 			if _, ok := deployedUnits[u.Name]; ok {
-				log.Printf("Unit [%v] was already deployed", u.Name)
+				log.Printf("DEBUG Unit [%v] was already deployed", u.Name)
 				continue
 			}
 

--- a/deployer.go
+++ b/deployer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coreos/fleet/client"
 	"github.com/coreos/fleet/schema"
 	"github.com/coreos/fleet/unit"
+	"github.com/kr/pretty"
 	"golang.org/x/net/proxy"
 	"gopkg.in/yaml.v2"
 )
@@ -142,6 +143,9 @@ func (d *deployer) deployUnit(wantedUnit *schema.Unit) error {
 
 	wuf := schema.MapSchemaUnitOptionsToUnitFile(wantedUnit.Options)
 	cuf := schema.MapSchemaUnitOptionsToUnitFile(currentUnit.Options)
+
+	log.Printf("Wanted Unit: %# v", pretty.Formatter(wuf))
+	log.Printf("Current Unit: %# v", pretty.Formatter(cuf))
 	if wuf.Hash() != cuf.Hash() {
 		log.Printf("INFO Service %s differs from the cluster version", wantedUnit.Name)
 		wantedUnit.DesiredState = "inactive"
@@ -188,7 +192,6 @@ func (d *deployer) launchAll(wantedUnits, currentUnits map[string]*schema.Unit, 
 				return err
 			}
 		}
-		time.Sleep(time.Second * 1)
 	}
 
 	for _, u := range wantedUnits {

--- a/deployer_test.go
+++ b/deployer_test.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"errors"
-	"gopkg.in/yaml.v2"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 )
 
 var badServiceYaml = []byte(`---
@@ -102,7 +103,7 @@ func (msdc *mockGoodServiceDefinitionClient) serviceFile(service service) ([]byt
 func TestBuildWantedUnitsBad(t *testing.T) {
 	mockServiceDefinitionClient := &mockBadServiceDefinitionClient{}
 	d := &deployer{serviceDefinitionClient: mockServiceDefinitionClient}
-	wantedUnits, err := d.buildWantedUnits()
+	wantedUnits, _, err := d.buildWantedUnits()
 	if err != nil {
 		t.Errorf("wanted units threw an error: %v", err)
 	}
@@ -122,7 +123,7 @@ func TestBuildWantedUnitsBad(t *testing.T) {
 func TestBuildWantedUnitsGood(t *testing.T) {
 	mockServiceDefinitionClient := &mockGoodServiceDefinitionClient{}
 	d := &deployer{serviceDefinitionClient: mockServiceDefinitionClient}
-	wantedUnits, err := d.buildWantedUnits()
+	wantedUnits, _, err := d.buildWantedUnits()
 	if err != nil {
 		t.Errorf("wanted units threw an error: %v", err)
 	}
@@ -142,7 +143,7 @@ func TestBuildWantedUnitsGood(t *testing.T) {
 func TestBuildDesiredStateHandling(t *testing.T) {
 	mockServiceDefinitionClient := &mockGoodServiceDefinitionClient{}
 	d := &deployer{serviceDefinitionClient: mockServiceDefinitionClient}
-	wantedUnits, _ := d.buildWantedUnits()
+	wantedUnits, _, _ := d.buildWantedUnits()
 	//TODO would be nice to look at whats being passed to fleet here and assert on that
 	//d.launchAll(wantedUnits)
 


### PR DESCRIPTION
* for all services with `sequentialDeployment: true` property in `services.yaml`:
  * deploy the service on node 1
  * wait until sideckick 1 is up
  * deploy the service to node 2
  * wait until sidekick 2 is up
  * etc
* this ensures that we always have one instance of the application running at all times
 * we check for the sidekick to be up every 30 seconds, for a max. of 5 minutes 