### PR TITLE
Unit reload fix

### DIFF
--- a/deployer.go
+++ b/deployer.go
@@ -172,6 +172,13 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 	for _, srv := range servicesDefinition.Services {
 		vars := make(map[string]interface{})
 		serviceTemplate, err := d.serviceDefinitionClient.serviceFile(srv)
+		/*
+		service template on output:
+		interprets newlines
+		\ at line endings are left alone
+		\\\"url\\\" - left as it is in the service file
+		*/
+		 
 		log.Printf("DEBUG Service Template: [%s]\n", string(serviceTemplate))
 
 		if err != nil {
@@ -180,6 +187,10 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 		}
 		vars["version"] = srv.Version
 		serviceFile, err := renderedServiceFile(serviceTemplate, vars)
+		/*
+		Service file on output: 
+		same as service template
+		 */
 		log.Printf("DEBUG Service File : [%s]\n", serviceFile)
 
 		if err != nil {
@@ -189,6 +200,13 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 
 		// fleet deploy
 		uf, err := unit.NewUnitFile(serviceFile)
+		/*
+		New Unit file on output:
+		does not interpret newline
+		\ at line endings left alone
+		newline is represented as: \\n 
+		\\\\\\\"url\\\\\\\" - escapes every character - 3x\ and 1x"
+		 */
 		log.Printf("DEBUG New Unit File: [%# v]\n", pretty.Formatter(uf))
 		
 		if err != nil {
@@ -364,11 +382,12 @@ func (d *deployer) isUpdatedUnit(newUnit *schema.Unit) (bool, error) {
 	}
 
 	log.Printf("DEBUG CurrentUnit for name [%s]: %# v \n", newUnit.Name, pretty.Formatter(currentUnit))
+	log.Printf("DEBUG NewUnit     for name [%s]: %# v \n", newUnit.Name, pretty.Formatter(newUnit))
 	nuf := schema.MapSchemaUnitOptionsToUnitFile(newUnit.Options)
 	cuf := schema.MapSchemaUnitOptionsToUnitFile(currentUnit.Options)
 
-	log.Printf("DEBUG New Unitfile: %# v \n", nuf)
-	log.Printf("DEBUG Current Unitfile: %# v \n", cuf)
+	log.Printf("DEBUG New Unitfile: %# v \n", pretty.Formatter(nuf))
+	log.Printf("DEBUG Current Unitfile: %# v \n", pretty.Formatter(cuf))
 
 	log.Printf("DEBUG New Unitfile hash: [%v] \n", nuf.Hash())
 	log.Printf("DEBUG Current Unitfile hash: [%v] \n", cuf.Hash())

--- a/deployer.go
+++ b/deployer.go
@@ -216,7 +216,7 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 		
 		log.Printf("DEBUG New Unit File: \n[%# v]\n", pretty.Formatter(uf))
 		for _, option := range uf.Options{
-			option.Value =  strings.Replace(option.Value,"\\\n","",-1)
+			option.Value =  strings.Replace(option.Value,"\\\n"," ",-1)
 		}
 		log.Printf("DEBUG New Unit File after newline removal: \n [%# v]\n", pretty.Formatter(uf))
 

--- a/deployer.go
+++ b/deployer.go
@@ -177,8 +177,6 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 		}
 		vars["version"] = srv.Version
 		serviceFile, err := renderedServiceFile(serviceTemplate, vars)
-		log.Printf("DEBUG Service File : [%s]\n", serviceFile)
-
 		if err != nil {
 			log.Printf("%v", err)
 			return nil, nil, err
@@ -192,11 +190,9 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 			continue
 		}
 		
-		log.Printf("DEBUG New Unit File: \n[%# v]\n", pretty.Formatter(uf))
 		for _, option := range uf.Options{
 			option.Value =  strings.Replace(option.Value,"\\\n"," ",-1)
 		}
-		log.Printf("DEBUG New Unit File after newline removal: \n [%# v]\n", pretty.Formatter(uf))
 
 		if srv.Count == 0 && !strings.Contains(srv.Name, "@") {
 			u := &schema.Unit{

--- a/deployer.go
+++ b/deployer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coreos/fleet/client"
 	"github.com/coreos/fleet/schema"
 	"github.com/coreos/fleet/unit"
+	"github.com/kr/pretty"
 	"golang.org/x/net/proxy"
 )
 
@@ -62,6 +63,9 @@ func (d *deployer) deployAll() error {
 	// Get service definition - wanted units
 	//get whitelist
 	wantedUnits, zddUnits, err := d.buildWantedUnits()
+	log.Printf("DEBUG wantedUnits: %# v\n", pretty.Formatter(wantedUnits))
+	log.Printf("DEBUG zddUnits: %# v\n", pretty.Formatter(wantedUnits))
+
 	deployedUnits := make(map[string]bool)
 
 	if err != nil {
@@ -346,14 +350,21 @@ func (d *deployer) launchAll(wantedUnits, currentUnits map[string]*schema.Unit, 
 }
 
 func (d *deployer) isUpdatedUnit(newUnit *schema.Unit) (bool, error) {
+	log.Printf("DEBUG Determining if unit [%s] is a an updated unit \n", newUnit.Name)
 	currentUnit, err := d.fleetapi.Unit(newUnit.Name)
 	if err != nil {
 		return false, err
 	}
 
+	log.Printf("DEBUG CurrentUnit for name [%s]: %# v \n", newUnit.Name, pretty.Formatter(currentUnit))
 	nuf := schema.MapSchemaUnitOptionsToUnitFile(newUnit.Options)
 	cuf := schema.MapSchemaUnitOptionsToUnitFile(currentUnit.Options)
 
+	log.Printf("DEBUG New Unitfile: %# v \n", nuf)
+	log.Printf("DEBUG Current Unitfile: %# v \n", cuf)
+	
+	log.Printf("DEBUG New Unitfile hash: [%v] \n", nuf.Hash())
+	log.Printf("DEBUG Current Unitfile hash: [%v] \n", cuf.Hash())
 	return nuf.Hash() != cuf.Hash(), nil
 }
 

--- a/deployer.go
+++ b/deployer.go
@@ -207,8 +207,12 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 		newline is represented as: \\n 
 		\\\\\\\"url\\\\\\\" - escapes every character - 3x\ and 1x"
 		 */
-		log.Printf("DEBUG New Unit File: [%# v]\n", pretty.Formatter(uf))
-		
+		log.Printf("DEBUG New Unit File: \n[%# v]\n", pretty.Formatter(uf))
+		for _, option := range uf.Options{
+			option.Value =  strings.Replace(option.Value,"\\\n","",-1)
+		}
+		log.Printf("DEBUG New Unit File after newline removal: \n [%# v]\n", pretty.Formatter(uf))
+
 		if err != nil {
 			//Broken service file, skip it and continue
 			log.Printf("WARNING service file %s is incorrect: %v [SKIPPING]", srv.Name, err)

--- a/deployer.go
+++ b/deployer.go
@@ -207,17 +207,18 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 		newline is represented as: \\n 
 		\\\\\\\"url\\\\\\\" - escapes every character - 3x\ and 1x"
 		 */
-		log.Printf("DEBUG New Unit File: \n[%# v]\n", pretty.Formatter(uf))
-		for _, option := range uf.Options{
-			option.Value =  strings.Replace(option.Value,"\\\n","",-1)
-		}
-		log.Printf("DEBUG New Unit File after newline removal: \n [%# v]\n", pretty.Formatter(uf))
 
 		if err != nil {
 			//Broken service file, skip it and continue
 			log.Printf("WARNING service file %s is incorrect: %v [SKIPPING]", srv.Name, err)
 			continue
 		}
+		
+		log.Printf("DEBUG New Unit File: \n[%# v]\n", pretty.Formatter(uf))
+		for _, option := range uf.Options{
+			option.Value =  strings.Replace(option.Value,"\\\n","",-1)
+		}
+		log.Printf("DEBUG New Unit File after newline removal: \n [%# v]\n", pretty.Formatter(uf))
 
 		if srv.Count == 0 && !strings.Contains(srv.Name, "@") {
 			u := &schema.Unit{

--- a/deployer.go
+++ b/deployer.go
@@ -14,12 +14,16 @@ import (
 	"github.com/coreos/fleet/unit"
 	"github.com/kr/pretty"
 	"golang.org/x/net/proxy"
+	"regexp"
 )
 
 type deployer struct {
 	fleetapi                client.API
 	serviceDefinitionClient serviceDefinitionClient
 }
+
+var whitespaceMatcher, _  = regexp.Compile("\\s+")
+
 
 func newDeployer() (*deployer, error) {
 	u, err := url.Parse(*fleetEndpoint)
@@ -391,10 +395,17 @@ func (d *deployer) isUpdatedUnit(newUnit *schema.Unit) (bool, error) {
 	nuf := schema.MapSchemaUnitOptionsToUnitFile(newUnit.Options)
 	cuf := schema.MapSchemaUnitOptionsToUnitFile(currentUnit.Options)
 
+	for _, option := range nuf.Options{
+		option.Value = whitespaceMatcher.ReplaceAllString(option.Value, " ")
+	}
+	for _, option := range cuf.Options{
+		option.Value = whitespaceMatcher.ReplaceAllString(option.Value, " ")
+	}
+	
 	log.Printf("DEBUG New Unitfile: %# v \n", pretty.Formatter(nuf))
 	log.Printf("DEBUG Current Unitfile: %# v \n", pretty.Formatter(cuf))
 
-	log.Printf("DEBUG New Unitfile hash: [%v] \n", nuf.Hash())
+	log.Printf("DEBUG New Unitfile     hash: [%v] \n", nuf.Hash())
 	log.Printf("DEBUG Current Unitfile hash: [%v] \n", cuf.Hash())
 	return nuf.Hash() != cuf.Hash(), nil
 }

--- a/deployer.go
+++ b/deployer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/coreos/fleet/client"
 	"github.com/coreos/fleet/schema"
 	"github.com/coreos/fleet/unit"
-	"github.com/kr/pretty"
 	"golang.org/x/net/proxy"
 	"regexp"
 )
@@ -369,11 +368,8 @@ func (d *deployer) isUpdatedUnit(newUnit *schema.Unit) (bool, error) {
 		option.Value = whitespaceMatcher.ReplaceAllString(option.Value, " ")
 	}
 	
-	log.Printf("DEBUG New Unitfile: %# v \n", pretty.Formatter(nuf))
-	log.Printf("DEBUG Current Unitfile: %# v \n", pretty.Formatter(cuf))
-
-	log.Printf("DEBUG New Unitfile     hash: [%v] \n", nuf.Hash())
-	log.Printf("DEBUG Current Unitfile hash: [%v] \n", cuf.Hash())
+	log.Printf("DEBUG New      hash: [%v] \n", nuf.Hash())
+	log.Printf("DEBUG Current  hash: [%v] \n", cuf.Hash())
 	return nuf.Hash() != cuf.Hash(), nil
 }
 

--- a/deployer.go
+++ b/deployer.go
@@ -367,9 +367,7 @@ func (d *deployer) isUpdatedUnit(newUnit *schema.Unit) (bool, error) {
 	for _, option := range cuf.Options{
 		option.Value = whitespaceMatcher.ReplaceAllString(option.Value, " ")
 	}
-	
-	log.Printf("DEBUG New      hash: [%v] \n", nuf.Hash())
-	log.Printf("DEBUG Current  hash: [%v] \n", cuf.Hash())
+
 	return nuf.Hash() != cuf.Hash(), nil
 }
 

--- a/deployer.go
+++ b/deployer.go
@@ -164,6 +164,7 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 	zddUnits := make(map[string]zddInfo)
 
 	servicesDefinition, err := d.serviceDefinitionClient.servicesDefinition()
+	log.Printf("DEBUG Services Definitions: [%# v]\n", pretty.Formatter(servicesDefinition))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -171,12 +172,16 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 	for _, srv := range servicesDefinition.Services {
 		vars := make(map[string]interface{})
 		serviceTemplate, err := d.serviceDefinitionClient.serviceFile(srv)
+		log.Printf("DEBUG Service Template: [%s]\n", string(serviceTemplate))
+
 		if err != nil {
 			log.Printf("%v", err)
 			continue
 		}
 		vars["version"] = srv.Version
 		serviceFile, err := renderedServiceFile(serviceTemplate, vars)
+		log.Printf("DEBUG Service File : [%s]\n", serviceFile)
+
 		if err != nil {
 			log.Printf("%v", err)
 			return nil, nil, err
@@ -184,6 +189,8 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 
 		// fleet deploy
 		uf, err := unit.NewUnitFile(serviceFile)
+		log.Printf("DEBUG New Unit File: [%# v]\n", pretty.Formatter(uf))
+		
 		if err != nil {
 			//Broken service file, skip it and continue
 			log.Printf("WARNING service file %s is incorrect: %v [SKIPPING]", srv.Name, err)
@@ -362,7 +369,7 @@ func (d *deployer) isUpdatedUnit(newUnit *schema.Unit) (bool, error) {
 
 	log.Printf("DEBUG New Unitfile: %# v \n", nuf)
 	log.Printf("DEBUG Current Unitfile: %# v \n", cuf)
-	
+
 	log.Printf("DEBUG New Unitfile hash: [%v] \n", nuf.Hash())
 	log.Printf("DEBUG Current Unitfile hash: [%v] \n", cuf.Hash())
 	return nuf.Hash() != cuf.Hash(), nil


### PR DESCRIPTION
* the fix below solves the issue introduced by https://github.com/coreos/go-systemd/pull/108/files#diff-a3c5371f1d6d3d7bb3e4b9f2b2049332R207 https://github.com/coreos/fleet/pull/1375
* replaces the escaped newline with a space
* replaces multiple spaces with a single space
* the two steps above ensure that the hash (which is calculated based on the options) is identical for units which have identical content
* this solution is not ideal and we should think about "normalizing" the service files before they are processed by the deployer
