### PR TITLE
Fix two stage loading

### DIFF
--- a/deployer.go
+++ b/deployer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/coreos/fleet/unit"
 	"golang.org/x/net/proxy"
 	"regexp"
+	"github.com/kr/pretty"
 )
 
 type deployer struct {
@@ -103,6 +104,7 @@ func (d *deployer) deployAll() error {
 
 		//for updated apps which need zero downtime deployment, we do that here
 		log.Printf("DEBUG Unit [%v] is  updated", u.Name)
+		log.Printf("DEBUG Unit in full: %# v", pretty.Formatter(u))
 		if _, ok := zddUnits[u.Name]; ok {
 			log.Printf("DEBUG Unit [%v] is ZDD ", u.Name)
 
@@ -339,6 +341,7 @@ func (d *deployer) destroyUnwanted(wantedUnits, currentUnits map[string]*schema.
 
 func (d *deployer) launchAll(wantedUnits, currentUnits map[string]*schema.Unit, zddUnits map[string]zddInfo) error {
 	for _, u := range wantedUnits {
+		log.Printf("Launching [%s], with desired state [%s]", u.Name, u.DesiredState)
 		if u.DesiredState == "" {
 			u.DesiredState = "launched"
 		}

--- a/deployer.go
+++ b/deployer.go
@@ -104,7 +104,6 @@ func (d *deployer) deployAll() error {
 
 		//for updated apps which need zero downtime deployment, we do that here
 		log.Printf("DEBUG Unit [%v] is  updated", u.Name)
-		log.Printf("DEBUG Unit desired state: %s", u.DesiredState)
 		if _, ok := zddUnits[u.Name]; ok {
 			log.Printf("DEBUG Unit [%v] is ZDD ", u.Name)
 
@@ -132,14 +131,14 @@ func (d *deployer) deployAll() error {
 			log.Printf("WARNING Failed to destroy unit %s: %v [SKIPPING]", u.Name, err)
 			continue
 		}
-		log.Printf("DEBUG Unit desired state after destroying: %s", u.DesiredState)
 
 		err = d.fleetapi.CreateUnit(u)
 		if err != nil {
 			log.Printf("WARNING Failed to create unit %s: %v [SKIPPING]", u.Name, err)
 			continue
 		}
-		log.Printf("DEBUG Unit desired state after creating: %s", u.DesiredState)
+		//destroying a unit sets it's state to 'Inactive'
+		u.DesiredState = ""
 	}
 
 	currentUnits, err := d.buildCurrentUnits()
@@ -342,7 +341,6 @@ func (d *deployer) destroyUnwanted(wantedUnits, currentUnits map[string]*schema.
 
 func (d *deployer) launchAll(wantedUnits, currentUnits map[string]*schema.Unit, zddUnits map[string]zddInfo) error {
 	for _, u := range wantedUnits {
-		log.Printf("Launching [%s], with desired state [%s]", u.Name, u.DesiredState)
 		if u.DesiredState == "" {
 			u.DesiredState = "launched"
 		}


### PR DESCRIPTION
* if a unit is updated, it's destroyed, then re-created with the updated content - this also causes the `DesiredState` to be set to `Inactive` - the deployer ignores this: it only sets the `DesiredState` to `launched` for units which don't have a desired state. This was introduced when we added support for the `Loaded` state for the Mongo backup service
* the desired state is only empty on the second run after the update, not really sure why
* the solution is to reset the `DesiredState` for an updated unit after it's re-created
* functional change is on lines 140-141, the rest is formatting
* tried it out in the `deployer-testing` cluster, it did the update in one run