### PR TITLE
Abort run if we can't read the service files

### DIFF
--- a/deployer.go
+++ b/deployer.go
@@ -166,6 +166,7 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 
 	servicesDefinition, err := d.serviceDefinitionClient.servicesDefinition()
 	if err != nil {
+		log.Printf("ERROR Cannot read services definition: [%v]. \nAborting run!", err)
 		return nil, nil, err
 	}
 
@@ -173,8 +174,8 @@ func (d *deployer) buildWantedUnits() (map[string]*schema.Unit, map[string]zddIn
 		vars := make(map[string]interface{})
 		serviceTemplate, err := d.serviceDefinitionClient.serviceFile(srv)
 		if err != nil {
-			log.Printf("%v", err)
-			continue
+			log.Printf("ERROR  Cannot read service file for unit [%s]: %v \nAborting run!", srv.Name, err)
+			return nil, nil, err
 		}
 		vars["version"] = srv.Version
 		serviceFile, err := renderedServiceFile(serviceTemplate, vars)


### PR DESCRIPTION
* cannot test this one - I tried to delete a service file altogether but that crashed the deployer :) 
* will let it soak in XP and see if more ` read: connection reset by peer` errors appear 