### PR TITLE
Cache hash

### DIFF
--- a/deployer.go
+++ b/deployer.go
@@ -136,21 +136,9 @@ func (d *deployer) buildUnitCache() (map[string]unit.Hash, error) {
 
 	unitCache := make(map[string]unit.Hash)
 	for _, unit := range units {
-		unitFile := schema.MapSchemaUnitOptionsToUnitFile(unit.Options)
-		for _, option := range unitFile.Options {
-			option.Value = whitespaceMatcher.ReplaceAllString(option.Value, " ")
-		}
-		unitCache[unit.Name] = unitFile.Hash()
+		unitCache[unit.Name] = getUnitHash(unit)
 	}
 	return unitCache, nil
-}
-
-func getUnitHash(unit *schema.Unit) unit.Hash {
-	unitFile := schema.MapSchemaUnitOptionsToUnitFile(unit.Options)
-	for _, option := range unitFile.Options {
-		option.Value = whitespaceMatcher.ReplaceAllString(option.Value, " ")
-	}
-	return unitFile.Hash()
 }
 
 func (d *deployer) identifyNewServiceGroups(serviceGroups map[string]serviceGroup) map[string]serviceGroup {
@@ -440,7 +428,7 @@ func (d *deployer) launchAll(serviceGroups map[string]serviceGroup) error {
 func (d *deployer) isUpdatedUnit(newUnit *schema.Unit) bool {
 	currentUnitHash, ok := d.unitCache[newUnit.Name]
 	if !ok {
-		log.Println("ERROR Current unit not found in cache, marking as NOT updated: [%s]", newUnit.Name)
+		log.Printf("ERROR Current unit not found in cache, marking as NOT updated: [%s]", newUnit.Name)
 		return false
 	}
 	newUnitFile := schema.MapSchemaUnitOptionsToUnitFile(newUnit.Options)
@@ -564,4 +552,12 @@ func getServiceName(unitName string) string {
 		return strings.Split(unitName, "@")[0]
 	}
 	return strings.Split(unitName, ".service")[0] //not templated
+}
+
+func getUnitHash(unit *schema.Unit) unit.Hash {
+	unitFile := schema.MapSchemaUnitOptionsToUnitFile(unit.Options)
+	for _, option := range unitFile.Options {
+		option.Value = whitespaceMatcher.ReplaceAllString(option.Value, " ")
+	}
+	return unitFile.Hash()
 }

--- a/deployer.go
+++ b/deployer.go
@@ -121,11 +121,13 @@ func (d *deployer) updateCache(serviceGroups map[string]serviceGroup) {
 			d.unitCache[u.Name] = getUnitHash(u)
 		}
 	}
-	log.Printf("DEBUG Updated unit cache: [%# v]\n", pretty.Formatter(d.unitCache))
+	if len(serviceGroups) > 0 {
+		log.Printf("DEBUG Updated unit cache: [%# v]\n", pretty.Formatter(d.unitCache))
+	}
 }
 
-func (d *deployer) removeFromCache(toRemove map[string]serviceGroup) {
-	for _, sg := range toRemove {
+func (d *deployer) removeFromCache(serviceGroups map[string]serviceGroup) {
+	for _, sg := range serviceGroups {
 		for _, u := range sg.serviceNodes {
 			delete(d.unitCache, u.Name)
 		}
@@ -133,7 +135,9 @@ func (d *deployer) removeFromCache(toRemove map[string]serviceGroup) {
 			delete(d.unitCache, u.Name)
 		}
 	}
-	log.Printf("DEBUG Updated unit cache: [%# v]\n", pretty.Formatter(d.unitCache))
+	if len(serviceGroups) > 0 {
+		log.Printf("DEBUG Updated unit cache: [%# v]\n", pretty.Formatter(d.unitCache))
+	}
 }
 func (d *deployer) buildUnitCache() (map[string]unit.Hash, error) {
 	log.Println("DEBUG Bulding unit cache.")

--- a/deployer.go
+++ b/deployer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/coreos/fleet/client"
 	"github.com/coreos/fleet/schema"
 	"github.com/coreos/fleet/unit"
-	"github.com/kr/pretty"
 	"golang.org/x/net/proxy"
 )
 
@@ -96,11 +95,6 @@ func (d *deployer) deployAll() error {
 	d.updateServiceGroupsSKsSequentially(toUpdateSKSequentially)
 	d.deleteServiceGroups(toDelete)
 
-	log.Printf("toUpdateRegular:        [%v]", toUpdateRegular)
-	log.Printf("toUpdateSequentially:   [%v]", toUpdateSequentially)
-	log.Printf("toUpdateSKRegular:      [%v]", toUpdateSKRegular)
-	log.Printf("toUpdateSKSequentially: [%v]", toUpdateSKSequentially)
-
 	d.updateCache(mergeMaps(toCreate, toUpdateRegular, toUpdateSequentially, toUpdateSKRegular, toUpdateSKSequentially))
 	d.removeFromCache(toDelete)
 
@@ -121,9 +115,6 @@ func (d *deployer) updateCache(serviceGroups map[string]serviceGroup) {
 			d.unitCache[u.Name] = getUnitHash(u)
 		}
 	}
-	if len(serviceGroups) > 0 {
-		log.Printf("DEBUG Updated unit cache: [%# v]\n", pretty.Formatter(d.unitCache))
-	}
 }
 
 func (d *deployer) removeFromCache(serviceGroups map[string]serviceGroup) {
@@ -135,12 +126,9 @@ func (d *deployer) removeFromCache(serviceGroups map[string]serviceGroup) {
 			delete(d.unitCache, u.Name)
 		}
 	}
-	if len(serviceGroups) > 0 {
-		log.Printf("DEBUG Updated unit cache: [%# v]\n", pretty.Formatter(d.unitCache))
-	}
 }
+
 func (d *deployer) buildUnitCache() (map[string]unit.Hash, error) {
-	log.Println("DEBUG Bulding unit cache.")
 	units, err := d.fleetapi.Units()
 	if err != nil {
 		return nil, err
@@ -154,7 +142,6 @@ func (d *deployer) buildUnitCache() (map[string]unit.Hash, error) {
 		}
 		unitCache[unit.Name] = unitFile.Hash()
 	}
-	log.Printf("DEBUG Bulding unit cache done: [%# v]\n", pretty.Formatter(unitCache))
 	return unitCache, nil
 }
 
@@ -453,8 +440,7 @@ func (d *deployer) launchAll(serviceGroups map[string]serviceGroup) error {
 func (d *deployer) isUpdatedUnit(newUnit *schema.Unit) bool {
 	currentUnitHash, ok := d.unitCache[newUnit.Name]
 	if !ok {
-		log.Println("ERROR Current unit not found in cache: [%s]", newUnit.Name)
-		//TODO handle differently?
+		log.Println("ERROR Current unit not found in cache, marking as NOT updated: [%s]", newUnit.Name)
 		return false
 	}
 	newUnitFile := schema.MapSchemaUnitOptionsToUnitFile(newUnit.Options)

--- a/deployer.go
+++ b/deployer.go
@@ -64,7 +64,6 @@ func newDeployer() (*deployer, error) {
 		fleetHTTPAPIClient = noDestroyFleetAPI{fleetHTTPAPIClient}
 	}
 	serviceDefinitionClient := &httpServiceDefinitionClient{httpClient: &http.Client{}, rootURI: *rootURI}
-
 	return &deployer{fleetapi: fleetHTTPAPIClient, serviceDefinitionClient: serviceDefinitionClient}, nil
 }
 
@@ -72,7 +71,7 @@ func (d *deployer) deployAll() error {
 	if d.unitCache == nil {
 		uc, err := d.buildUnitCache()
 		if err != nil {
-			log.Printf("Cannot build unit cache, aborting run: [%v]", err)
+			log.Printf("ERROR Cannot build unit cache, aborting run: [%v]", err)
 			return err
 		}
 		d.unitCache = uc
@@ -394,7 +393,6 @@ func (d *deployer) waitForUnitToLaunch(unitName string) {
 	}
 }
 
-//only name and desireState of the units are used
 func (d *deployer) buildCurrentUnits() (map[string]*schema.Unit, error) {
 	all, err := d.fleetapi.Units()
 	if err != nil {

--- a/deployer.go
+++ b/deployer.go
@@ -431,11 +431,7 @@ func (d *deployer) isUpdatedUnit(newUnit *schema.Unit) bool {
 		log.Printf("ERROR Current unit not found in cache, marking as NOT updated: [%s]", newUnit.Name)
 		return false
 	}
-	newUnitFile := schema.MapSchemaUnitOptionsToUnitFile(newUnit.Options)
-	for _, option := range newUnitFile.Options {
-		option.Value = whitespaceMatcher.ReplaceAllString(option.Value, " ")
-	}
-	return newUnitFile.Hash() != currentUnitHash
+	return getUnitHash(newUnit) != currentUnitHash
 }
 
 func (d *deployer) makeServiceFile(s service) (string, error) {


### PR DESCRIPTION
- added a cache to hold the unit hashes
- this reduces the number of calls we make to `etcd` and fixes the situations where we got out-of-date or empty data from `etcd`, leading to repeated updates and unnecessary reloads and downtime
