### PR TITLE
Update deployer version

### DIFF
--- a/deployer.service
+++ b/deployer.service
@@ -4,7 +4,7 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Environment="DOCKER_APP_VERSION=1.0.3"
+Environment="DOCKER_APP_VERSION=1.1.2"
 TimeoutStartSec=0
 KillMode=none
 ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p > /dev/null 2>&1'


### PR DESCRIPTION
- this may change but `1.1.2` is stable so far, considering the fact that we have an OS upgrade to do, this should be updated