### PR TITLE
Sequential deployment check __health instead of unit state 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN apk --update add go git gcc linux-headers libc-dev \
   && apk del go git gcc linux-headers libc-dev \
   && rm -rf $GOPATH /var/cache/apk/*
 
-CMD /coco-fleet-deployer -fleetEndpoint=$FLEET_ENDPOINT -rootURI=$ROOT_URI -destroy=$DESTROY -isDebug=$IS_DEBUG
+CMD /coco-fleet-deployer -fleetEndpoint=$FLEET_ENDPOINT -rootURI=$ROOT_URI -destroy=$DESTROY -isDebug=$IS_DEBUG -etcd-url=$ETCD_URL -gtg-url=$GTG_URL
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN apk --update add go git gcc linux-headers libc-dev \
   && apk del go git gcc linux-headers libc-dev \
   && rm -rf $GOPATH /var/cache/apk/*
 
-CMD /coco-fleet-deployer -fleetEndpoint=$FLEET_ENDPOINT -rootURI=$ROOT_URI -destroy=$DESTROY -isDebug=$IS_DEBUG -etcd-url=$ETCD_URL -health-url-prefix=$HEALTH_URL_PREFIX
+CMD /coco-fleet-deployer -fleetEndpoint=$FLEET_ENDPOINT -rootURI=$ROOT_URI -destroy=$DESTROY -isDebug=$IS_DEBUG -etcd-url=$ETCD_URL -health-url-prefix=$HEALTH_URL_PREFIX -health-endpoint=$HEALTH_ENDPOINT -service-name-prefix=$SERVICE_NAME_PREFIX
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN apk --update add go git gcc linux-headers libc-dev \
   && apk del go git gcc linux-headers libc-dev \
   && rm -rf $GOPATH /var/cache/apk/*
 
-CMD /coco-fleet-deployer -fleetEndpoint=$FLEET_ENDPOINT -rootURI=$ROOT_URI -destroy=$DESTROY -isDebug=$IS_DEBUG -etcd-url=$ETCD_URL -gtg-url=$GTG_URL
+CMD /coco-fleet-deployer -fleetEndpoint=$FLEET_ENDPOINT -rootURI=$ROOT_URI -destroy=$DESTROY -isDebug=$IS_DEBUG -etcd-url=$ETCD_URL -gtg-url-prefix=$GTG_URL_PREFIX
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN apk --update add go git gcc linux-headers libc-dev \
   && apk del go git gcc linux-headers libc-dev \
   && rm -rf $GOPATH /var/cache/apk/*
 
-CMD /coco-fleet-deployer -fleetEndpoint=$FLEET_ENDPOINT -rootURI=$ROOT_URI -destroy=$DESTROY -isDebug=$IS_DEBUG -etcd-url=$ETCD_URL -gtg-url-prefix=$GTG_URL_PREFIX
+CMD /coco-fleet-deployer -fleetEndpoint=$FLEET_ENDPOINT -rootURI=$ROOT_URI -destroy=$DESTROY -isDebug=$IS_DEBUG -etcd-url=$ETCD_URL -health-url-prefix=$HEALTH_URL_PREFIX
 

--- a/deployer.go
+++ b/deployer.go
@@ -26,7 +26,7 @@ type deployer struct {
 	isDebug                 bool
 	etcdapi                 etcdClient.KeysAPI
 	httpClient              *http.Client
-	gtgURL                  string
+	gtgURLPrefix            string
 }
 
 const launchedState = "launched"
@@ -95,7 +95,7 @@ func newDeployer() (*deployer, error) {
 		isDebug:                 *isDebug,
 		etcdapi:                 etcdapi,
 		httpClient:              httpClient,
-		gtgURL:                  *gtgURL,
+		gtgURLPrefix:            *gtgURLPrefix,
 	}, nil
 }
 
@@ -447,7 +447,7 @@ func (d *deployer) checkUnitState(unitName string) bool {
 }
 
 func (d *deployer) checkUnitHealth(unitName string) bool {
-	gtgPath := fmt.Sprintf("%s/__%s/__gtg", d.gtgURL, getServiceName(unitName))
+	gtgPath := fmt.Sprintf("%s/__%s/__gtg", d.gtgURLPrefix, getServiceName(unitName))
 	gtgResp, err := d.httpClient.Get(gtgPath)
 	if err != nil {
 		log.Printf("ERROR Error calling %s: %v", gtgPath, err.Error())

--- a/deployer.go
+++ b/deployer.go
@@ -368,8 +368,14 @@ func (d *deployer) performSequentialDeployment(sg serviceGroup) {
 		}
 
 		if d.hasGTG(u.Name) {
+			if d.isDebug {
+				log.Printf("DEBUG Service %s has a GTG endpoint - will be used for sequential deployment check.", u.Name)
+			}
 			d.waitForUnitToLaunch(u.Name, d.checkUnitHealth)
 		} else {
+			if d.isDebug {
+				log.Printf("DEBUG Service %s doesn't have a GTG endpoint - unit status will be used for sequential deployment check.", u.Name)
+			}
 			var unitToWaitOn string
 			if len(sg.sidekicks) == 0 {
 				unitToWaitOn = u.Name
@@ -434,10 +440,13 @@ func (d *deployer) checkUnitHealth(unitName string) bool {
 	gtgPath := fmt.Sprintf("%s/__%s/__gtg", d.gtgURL, getServiceName(unitName))
 	gtgResp, err := d.httpClient.Get(gtgPath)
 	if err != nil {
-		log.Printf("Error calling %s: %v", gtgPath, err.Error())
+		log.Printf("ERROR Error calling %s: %v", gtgPath, err.Error())
 		return false
 	}
 	gtgResp.Body.Close()
+	if d.isDebug {
+		log.Printf("DEBUG Called %s to get GTG for %s, result: %d.", gtgPath, unitName, gtgResp.StatusCode)
+	}
 	return gtgResp.StatusCode == http.StatusOK
 }
 

--- a/deployer.go
+++ b/deployer.go
@@ -27,6 +27,8 @@ type deployer struct {
 	etcdapi                 etcdClient.KeysAPI
 	httpClient              *http.Client
 	healthURLPrefix         string
+	healthEndpoint          string
+	serviceNamePrefix       string
 }
 
 const launchedState = "launched"
@@ -96,6 +98,8 @@ func newDeployer() (*deployer, error) {
 		etcdapi:                 etcdapi,
 		httpClient:              httpClient,
 		healthURLPrefix:         *healthURLPrefix,
+		healthEndpoint:          *healthEndpoint,
+		serviceNamePrefix:       *serviceNamePrefix,
 	}, nil
 }
 
@@ -447,7 +451,7 @@ func (d *deployer) checkUnitState(unitName string) bool {
 }
 
 func (d *deployer) checkUnitHealth(unitName string) bool {
-	hcPath := fmt.Sprintf("%s/__%s/__health", d.healthURLPrefix, getServiceName(unitName))
+	hcPath := fmt.Sprintf("%s/%s%s/%s", d.healthURLPrefix, d.serviceNamePrefix, getServiceName(unitName), d.healthEndpoint)
 	hcResp, err := d.httpClient.Get(hcPath)
 	if err != nil {
 		log.Printf("ERROR Error calling %s: %v", hcPath, err.Error())

--- a/deployer.go
+++ b/deployer.go
@@ -454,12 +454,16 @@ func (d *deployer) hasGTG(unitName string) bool {
 	etcdValuePath := fmt.Sprintf("/ft/services/%s/healthcheck", getServiceName(unitName))
 	etcdResp, err := d.etcdapi.Get(context.Background(), etcdValuePath, nil)
 	if err != nil {
-		log.Printf("Error while getting etcd key for app from %s: %v", etcdValuePath, err.Error())
+		log.Printf("ERROR Error while getting etcd key for app from %s: %v", etcdValuePath, err.Error())
+		return false
 	}
 	if etcdResp.Node == nil {
-		log.Printf("Error while getting etcd key for app from %s: node is nil", etcdValuePath)
+		log.Printf("ERROR Error while getting etcd key for app from %s: node is nil", etcdValuePath)
+		return false
 	}
-	log.Printf("HC node value: %s", etcdResp.Node.Value)
+	if d.isDebug {
+		log.Printf("Healthcheck setting value at %s is %s", etcdValuePath, etcdResp.Node.Value)
+	}
 	return etcdResp.Node.Value == "true"
 }
 

--- a/deployer.service
+++ b/deployer.service
@@ -12,6 +12,8 @@ ExecStartPre=-/bin/sh -c 'docker rm %p >/dev/null 2>&1'
 ExecStart=/bin/sh -c '\
   ROOT_URI=$(etcdctl get /ft/config/services-definition-root-uri); \
   IS_DEBUG=$(etcdctl get /ft/config/deployer/is-debug) || IS_DEBUG=false; \
+  HEALTH_ENDPOINT=$(etcdctl get /ft/config/deployer/health-endpoint) || HEALTH_ENDPOINT=__health; \
+  SERVICE_NAME_PREFIX=$(etcdctl get /ft/config/deployer/service-name-prefix) || SERVICE_NAME_PREFIX=__; \
   docker run -v "/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt" --rm --name %p \
   -e="DESTROY=true" \
   -e="IS_DEBUG=$IS_DEBUG" \
@@ -19,6 +21,8 @@ ExecStart=/bin/sh -c '\
   -e="HEALTH_URL_PREFIX=http://$HOSTNAME:8080" \
   -e="ETCD_URL=http://$HOSTNAME:2379" \
   -e="FLEET_ENDPOINT=http://$HOSTNAME:49153" \
+  -e="HEALTH_ENDPOINT=$HEALTH_ENDPOINT" \
+  -e="SERVICE_NAME_PREFIX=$SERVICE_NAME_PREFIX" \
   coco/coco-fleet-deployer:$DOCKER_APP_VERSION'
 ExecStop=/usr/bin/docker stop -t 3 %p
 Restart=on-failure

--- a/deployer.service
+++ b/deployer.service
@@ -16,7 +16,7 @@ ExecStart=/bin/sh -c '\
   -e="DESTROY=true" \
   -e="IS_DEBUG=$IS_DEBUG" \
   -e="ROOT_URI=$ROOT_URI" \
-  -e="GTG_URL=http://$HOSTNAME:8080" \
+  -e="GTG_URL_PREFIX=http://$HOSTNAME:8080" \
   -e="ETCD_URL=http://$HOSTNAME:2379" \
   -e="FLEET_ENDPOINT=http://$HOSTNAME:49153" \
   coco/coco-fleet-deployer:$DOCKER_APP_VERSION'

--- a/deployer.service
+++ b/deployer.service
@@ -12,8 +12,14 @@ ExecStartPre=-/bin/sh -c 'docker rm %p >/dev/null 2>&1'
 ExecStart=/bin/sh -c '\
   ROOT_URI=$(etcdctl get /ft/config/services-definition-root-uri); \
   IS_DEBUG=$(etcdctl get /ft/config/deployer/is-debug) || IS_DEBUG=false; \
-  docker run -v "/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt" --rm --name %p -e="FLEET_ENDPOINT=http://$HOSTNAME:49153" -e="ROOT_URI=$ROOT_URI" -e="DESTROY=true" -e="IS_DEBUG=$IS_DEBUG" coco/coco-fleet-deployer:$DOCKER_APP_VERSION'
+  docker run -v "/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt" --rm --name %p \
+  -e="DESTROY=true" \
+  -e="IS_DEBUG=$IS_DEBUG" \
+  -e="ROOT_URI=$ROOT_URI" \
+  -e="GTG_URL=http://$HOSTNAME:8080" \
+  -e="ETCD_URL=http://$HOSTNAME:2379" \
+  -e="FLEET_ENDPOINT=http://$HOSTNAME:49153" \
+  coco/coco-fleet-deployer:$DOCKER_APP_VERSION'
 ExecStop=/usr/bin/docker stop -t 3 %p
 Restart=on-failure
 RestartSec=10
-

--- a/deployer.service
+++ b/deployer.service
@@ -16,7 +16,7 @@ ExecStart=/bin/sh -c '\
   -e="DESTROY=true" \
   -e="IS_DEBUG=$IS_DEBUG" \
   -e="ROOT_URI=$ROOT_URI" \
-  -e="GTG_URL_PREFIX=http://$HOSTNAME:8080" \
+  -e="HEALTH_URL_PREFIX=http://$HOSTNAME:8080" \
   -e="ETCD_URL=http://$HOSTNAME:2379" \
   -e="FLEET_ENDPOINT=http://$HOSTNAME:49153" \
   coco/coco-fleet-deployer:$DOCKER_APP_VERSION'

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ var (
 	rootURI                 = flag.String("rootURI", "", "Base uri to use when constructing service file URI. Only used if service file URI is relative.")
 	isDebug                 = flag.Bool("isDebug", false, "Enable to show debug logs.")
 	etcdURL                 = flag.String("etcd-url", "http://localhost:2379", "etcd URL")
+	gtgURL                  = flag.String("gtg-url", "http://localhost:8080", "gtg URL")
 )
 
 type services struct {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/coreos/fleet/schema"
 )
 
+//TODO add env var support
 var (
 	destroyFlag             = flag.Bool("destroy", false, "Destroy units not found in the definition")
 	fleetEndpoint           = flag.String("fleetEndpoint", "", "Fleet API http endpoint: `http://host:port`")

--- a/main.go
+++ b/main.go
@@ -47,6 +47,14 @@ type serviceGroup struct {
 	isZDD        bool
 }
 
+type healthcheckResponse struct {
+	Name   string
+	Checks []struct {
+		Name string
+		OK   bool
+	}
+}
+
 func main() {
 	flag.Parse()
 	if *fleetEndpoint == "" {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var (
 	rootURI                 = flag.String("rootURI", "", "Base uri to use when constructing service file URI. Only used if service file URI is relative.")
 	isDebug                 = flag.Bool("isDebug", false, "Enable to show debug logs.")
 	etcdURL                 = flag.String("etcd-url", "http://localhost:2379", "etcd URL")
-	gtgURLPrefix            = flag.String("gtg-url-prefix", "http://localhost:8080", "gtg URL prefix")
+	healthURLPrefix         = flag.String("health-url-prefix", "http://localhost:8080", "health URL prefix")
 )
 
 type services struct {

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/coreos/fleet/schema"
+	"github.com/kr/pretty"
 )
 
 //TODO add env var support
@@ -61,6 +62,7 @@ func main() {
 		panic(err)
 	}
 
+	log.Printf("Using configuration: \n %# v \n", pretty.Formatter(d))
 	for {
 		log.Printf("Starting deploy run")
 		if err := d.deployAll(); err != nil {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var (
 	rootURI                 = flag.String("rootURI", "", "Base uri to use when constructing service file URI. Only used if service file URI is relative.")
 	isDebug                 = flag.Bool("isDebug", false, "Enable to show debug logs.")
 	etcdURL                 = flag.String("etcd-url", "http://localhost:2379", "etcd URL")
-	gtgURL                  = flag.String("gtg-url", "http://localhost:8080", "gtg URL")
+	gtgURLPrefix            = flag.String("gtg-url-prefix", "http://localhost:8080", "gtg URL prefix")
 )
 
 type services struct {

--- a/main.go
+++ b/main.go
@@ -70,7 +70,10 @@ func main() {
 		panic(err)
 	}
 
-	log.Printf("Using configuration: \n %# v \n", pretty.Formatter(d))
+	if d.isDebug {
+		log.Printf("DEBUG Using configuration: \n %# v \n", pretty.Formatter(d))
+	}
+
 	for {
 		log.Printf("Starting deploy run")
 		if err := d.deployAll(); err != nil {

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ var (
 	isDebug                 = flag.Bool("isDebug", false, "Enable to show debug logs.")
 	etcdURL                 = flag.String("etcd-url", "http://localhost:2379", "etcd URL")
 	healthURLPrefix         = flag.String("health-url-prefix", "http://localhost:8080", "health URL prefix")
+	healthEndpoint          = flag.String("health-endpoint", "__health", "health endpoint")
+	serviceNamePrefix       = flag.String("service-name-prefix", "__", "service name prefix")
 )
 
 type services struct {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ var (
 	destroyServiceBlacklist = map[string]struct{}{"deployer.service": struct{}{}, "deployer.timer": struct{}{}}
 	rootURI                 = flag.String("rootURI", "", "Base uri to use when constructing service file URI. Only used if service file URI is relative.")
 	isDebug                 = flag.Bool("isDebug", false, "Enable to show debug logs.")
+	etcdURL                 = flag.String("etcd-url", "http://localhost:2379", "etcd URL")
 )
 
 type services struct {


### PR DESCRIPTION
- affected use-case: application with sequential deployment gets updated
  - we check if the healthcheck value is set to true in etcd: `/ft/services/$SERVICE/healthcheck`
  - if it is, we use the app's `__health` endpoint to check that the app is up, and we're ready to bring down the next node (instead of using the unit status)
- the `__health` endpoint is a better indicator that the app is ready to serve requests than the unit state and this change should eliminate down times for apps with sequential deployment