### PR TITLE
Upgrade deployer in service file to 1.3.0

### DIFF
--- a/deployer.service
+++ b/deployer.service
@@ -4,7 +4,7 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Environment="DOCKER_APP_VERSION=1.2.3"
+Environment="DOCKER_APP_VERSION=1.3.0"
 TimeoutStartSec=0
 KillMode=none
 ExecStartPre=-/bin/sh -c 'docker kill %p >/dev/null 2>&1'


### PR DESCRIPTION
- changes since 1.2.3 : https://github.com/Financial-Times/coco-fleet-deployer/pull/52
- tested in XP on `nativerw` and `document-store-api` - while the deploy was in progress, I was running a curl to the app, and returned 200 throughout the deploy:

`watch -g -n2 curl -is https://foo:bar@xp-up.ft.com/__document-store-api/content/c5b6b5d2-2250-11e6-bcbe-930c95c2b12c  -w "%{http_code}" -o /dev/null`

- example output with debug on

```
2016/09/19 11:08:14 INFO Destroying unit document-store-api-sidekick@1.service
2016/09/19 11:08:14 INFO Creating or updating unit document-store-api-sidekick@1.service
2016/09/19 11:08:14 INFO Setting target state for document-store-api-sidekick@1.service to launched
2016/09/19 11:08:14 INFO Destroying unit document-store-api@1.service
2016/09/19 11:08:14 INFO Creating or updating unit document-store-api@1.service
2016/09/19 11:08:14 INFO Setting target state for document-store-api@1.service to launched
2016/09/19 11:08:14 DEBUG Healthcheck setting value at /ft/services/document-store-api/healthcheck is true
2016/09/19 11:08:14 DEBUG Service document-store-api@1.service has a healthcheck endpoint - will be used for sequential deployment check.
2016/09/19 11:08:44 DEBUG Called http://ip-172-24-162-176.eu-west-1.compute.internal:8080/__document-store-api/__health to get healthcheck for document-store-api@1.service.
DEBUG healthcheck response:
 &main.healthcheckResponse{
    Name:   "DocumentStoreApiApplication",
    Checks: {
        {Name:"Connectivity to MongoDB", OK:true},
    },
}
2016/09/19 11:08:44 INFO Destroying unit document-store-api-sidekick@2.service
2016/09/19 11:08:44 INFO Creating or updating unit document-store-api-sidekick@2.service
2016/09/19 11:08:44 INFO Setting target state for document-store-api-sidekick@2.service to launched
2016/09/19 11:08:44 INFO Destroying unit document-store-api@2.service
2016/09/19 11:08:44 INFO Creating or updating unit document-store-api@2.service
2016/09/19 11:08:44 INFO Setting target state for document-store-api@2.service to launched
```

* once this is approved I'll be promoting this version to pre-prod and then prod