### PR TITLE
Increase state check interval to 60 sec.

### DIFF
--- a/deployer.go
+++ b/deployer.go
@@ -39,7 +39,7 @@ type deployer struct {
 const launchedState = "launched"
 const inactiveState = "inactive"
 const launchTimeout = time.Duration(5) * time.Minute
-const stateCheckInterval = time.Duration(30) * time.Second
+const stateCheckInterval = time.Duration(60) * time.Second
 
 var whitespaceMatcher, _ = regexp.Compile("\\s+")
 

--- a/deployer.service
+++ b/deployer.service
@@ -4,7 +4,7 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Environment="DOCKER_APP_VERSION=1.3.1"
+Environment="DOCKER_APP_VERSION=1.3.2-ops-increaseStateCheck-rc1"
 TimeoutStartSec=0
 KillMode=none
 ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'

--- a/deployer.service
+++ b/deployer.service
@@ -4,7 +4,7 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Environment="DOCKER_APP_VERSION=1.3.2-ops-increaseStateCheck-rc1"
+Environment="DOCKER_APP_VERSION=1.3.2"
 TimeoutStartSec=0
 KillMode=none
 ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'

--- a/deployer.service
+++ b/deployer.service
@@ -4,7 +4,7 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Environment="DOCKER_APP_VERSION=1.3.2"
+Environment="DOCKER_APP_VERSION=1.3.2-ops-increaseStateCheck-rc1"
 TimeoutStartSec=0
 KillMode=none
 ExecStartPre=-/bin/bash -c '/usr/bin/docker kill "$(docker ps -q --filter=name=^/%p-%i_)" > /dev/null 2>&1'


### PR DESCRIPTION
Context:
Sequential deployment does not currently work as expected. 
See details [here](https://docs.google.com/document/d/1hDQjnoaXcsVsdFfHUOn4xugRABka8Uvo0_q0jsFP0Sg/edit#heading=h.nttijzy3x3p1).

Possible fixes:
1) In the deployer: check the health at instance level (and not application level!)- requires more time to investigate and implement
2) In the applications, avoiding the requests to be cut down - requires more effort

**Workaround to decrease the possibility of failures:** (implemented here)
Increase the state check interval - increasing the possibility for the newly deployed service to get to a healthy state.
⚠️ This won't block us from deploying unhealthy services, though! These kind of problems should be discovered in lower environments.

Current state:
- This version of the deployer needs to be tested in a newly provisioned cluster (use tag `1.3.2-ops-increaseStateCheck-rc1`)
- Confirm the time period looking at splunk logs (for enriched content and api policy component, deployed this week)

